### PR TITLE
Rename namespace for 'LAO Community'

### DIFF
--- a/src/namespaces.json
+++ b/src/namespaces.json
@@ -249,7 +249,7 @@
   "lao": {
     "key": "lao",
     "symbol": "LAO",
-    "name": "The LAO",
+    "name": "LAO Community",
     "defaultView": "all",
     "address": "0x8Ffb89D50eB0b9788f40123Cb3B8b8a84Edb4202",
     "token": "0x8Ffb89D50eB0b9788f40123Cb3B8b8a84Edb4202",


### PR DESCRIPTION
rename LAO space for "LAO Community" purposes (small nitpick :pray: )