### PR TITLE
Allow filtering invalid on Core

### DIFF
--- a/src/views/Proposals.vue
+++ b/src/views/Proposals.vue
@@ -103,7 +103,8 @@ export default {
 
             if (
               ['core', 'all'].includes(this.selectedState) &&
-              this.space.core.includes(proposal[1].address)
+              this.space.core.includes(proposal[1].address) &&
+              !this.space.invalid.includes(proposal[1].authorIpfsHash)
             )
               return true;
 


### PR DESCRIPTION
Currently the only way to make a proposal not show up outside of min token balance is to add the hash to invalids in the namespace. If Core dev wants to hide one of their proposals because of an issue with it, they can't because 'core' returns before 'invalid' in the filter process.

This PR adds a test such that if a proposal is invalid, it wont show up in Core.
