### PR TITLE
add web socket, block explorer url for ThaiChain

### DIFF
--- a/src/helpers/networks.json
+++ b/src/helpers/networks.json
@@ -21,7 +21,7 @@
     "network": "mainnet",
     "rpcUrl": "https://rpc.dome.cloud",
     "wsUrl": "wss://ws.dome.cloud",
-    "explorer": "http://exp.tch.in.th"
+    "explorer": "https://exp.tch.in.th"
   },
   "42": {
     "name": "Ethereum Testnet Kovan",

--- a/src/helpers/networks.json
+++ b/src/helpers/networks.json
@@ -20,7 +20,8 @@
     "chainId": 7,
     "network": "mainnet",
     "rpcUrl": "https://rpc.dome.cloud",
-    "explorer": ""
+    "wsUrl": "wss://ws.dome.cloud",
+    "explorer": "http://exp.tch.in.th"
   },
   "42": {
     "name": "Ethereum Testnet Kovan",


### PR DESCRIPTION
web socket url for ThaiChain (chainId 7): "wss://ws.dome.cloud"
block explorer url for ThaiChain (chainId 7): "http://exp.tch.in.th"

Fixes # .

Changes proposed in this pull request:
- 
- 
- 
