### PR TITLE
Add space.network to Gnosis plugin

### DIFF
--- a/src/components/Modal/Plugins.vue
+++ b/src/components/Modal/Plugins.vue
@@ -54,6 +54,7 @@
       <PluginGnosisConfig
         :value="form.gnosis"
         :proposal="proposal"
+        :network="space.network"
         v-model="form.gnosis"
         @close="selected = false"
         v-if="selected === 'gnosis'"

--- a/src/components/Plugin/Gnosis/Block.vue
+++ b/src/components/Plugin/Gnosis/Block.vue
@@ -75,7 +75,7 @@ import Plugin from '@snapshot-labs/snapshot.js/src/plugins/gnosis';
 import getProvider from '@snapshot-labs/snapshot.js/src/utils/provider';
 
 export default {
-  props: ['proposalConfig', 'choices'],
+  props: ['proposalConfig', 'choices', 'network'],
   data() {
     return {
       plugin: new Plugin(),
@@ -92,16 +92,16 @@ export default {
   },
   async created() {
     this.baseToken = await this.plugin.getTokenInfo(
-      getProvider(this.web3.network.key),
+      getProvider(this.network),
       this.proposalConfig.baseTokenAddress
     );
     this.baseTokenUrl = this.getLogoUrl(this.baseToken.checksumAddress);
     this.quoteToken = await this.plugin.getTokenInfo(
-      getProvider(this.web3.network.key),
+      getProvider(this.network),
       this.proposalConfig.quoteCurrencyAddress
     );
     const conditionQuery = await this.plugin.getOmenCondition(
-      this.web3.network.key,
+      this.network,
       this.proposalConfig.conditionId
     );
     this.baseProductMarketMaker = conditionQuery.condition.fixedProductMarketMakers.find(
@@ -112,7 +112,7 @@ export default {
     );
 
     const tokenPairQuery = await this.plugin.getUniswapPair(
-      this.web3.network.key,
+      this.network,
       this.proposalConfig.quoteCurrencyAddress,
       this.proposalConfig.baseTokenAddress
     );

--- a/src/components/Plugin/Gnosis/Block.vue
+++ b/src/components/Plugin/Gnosis/Block.vue
@@ -1,5 +1,8 @@
 <template>
   <Block title="Gnosis Impact" v-if="choices.length > 1">
+    <div v-if="loading" class="loading">
+      Loading...
+    </div>
     <div class="mb-1">
       <b>
         Predicted impact
@@ -78,6 +81,7 @@ export default {
   props: ['proposalConfig', 'choices', 'network'],
   data() {
     return {
+      loading: false,
       plugin: new Plugin(),
       baseToken: {},
       baseTokenUrl: '',
@@ -91,6 +95,7 @@ export default {
     };
   },
   async created() {
+    this.loading = true;
     this.baseToken = await this.plugin.getTokenInfo(
       getProvider(this.network),
       this.proposalConfig.baseTokenAddress
@@ -128,6 +133,7 @@ export default {
       ((this.priceFirstOption - this.priceSecondOption) /
         this.priceSecondOption) *
       100;
+    this.loading = false;
   },
   methods: {
     getLogoUrl(checksumAddress) {

--- a/src/components/Plugin/Gnosis/Block.vue
+++ b/src/components/Plugin/Gnosis/Block.vue
@@ -116,7 +116,10 @@ export default {
       this.proposalConfig.quoteCurrencyAddress,
       this.proposalConfig.baseTokenAddress
     );
-    if (tokenPairQuery !== undefined) {
+    if (
+      tokenPairQuery !== undefined &&
+      tokenPairQuery.token0Price !== undefined
+    ) {
       this.quoteCurrencyPrice = parseFloat(tokenPairQuery.token0Price);
     }
     this.priceFirstOption = this.getTokenPrice(0);

--- a/src/components/Plugin/Gnosis/Block.vue
+++ b/src/components/Plugin/Gnosis/Block.vue
@@ -116,8 +116,8 @@ export default {
       this.proposalConfig.quoteCurrencyAddress,
       this.proposalConfig.baseTokenAddress
     );
-    if (tokenPairQuery.pairs.length > 0) {
-      this.quoteCurrencyPrice = parseFloat(tokenPairQuery.pairs[0].token0Price);
+    if (tokenPairQuery !== undefined) {
+      this.quoteCurrencyPrice = parseFloat(tokenPairQuery.token0Price);
     }
     this.priceFirstOption = this.getTokenPrice(0);
     this.priceSecondOption = this.getTokenPrice(1);

--- a/src/components/Plugin/Gnosis/Config.vue
+++ b/src/components/Plugin/Gnosis/Config.vue
@@ -36,7 +36,11 @@
       </div>
     </div>
     <div v-if="this.preview">
-      <PluginGnosisBlock :proposalConfig="input" :choices="this.getChoices()" />
+      <PluginGnosisBlock
+        :proposalConfig="input"
+        :choices="this.getChoices()"
+        :network="this.network"
+      />
     </div>
     <UiButton
       v-if="!preview && input"
@@ -61,7 +65,7 @@
 
 <script>
 export default {
-  props: ['value', 'proposal'],
+  props: ['value', 'proposal', 'network'],
   data() {
     return {
       input: false,

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -158,6 +158,7 @@
           v-if="_get(payload, 'metadata.plugins.gnosis.baseTokenAddress')"
           :proposalConfig="payload.metadata.plugins.gnosis"
           :choices="payload.choices"
+          :network="space.network"
         />
       </div>
     </div>


### PR DESCRIPTION
- Replace tokenPairQuery from getting array values to compare object
  values with `token0Price` and `token1Price` Uniswap-V2 fields https://github.com/snapshot-labs/snapshot.js/pull/49.
- Replace `this.web3.network.key` to `space.network`. This will fix to ask for the right network id from the given space instead look for the network based on the Metamask user wallet. https://github.com/gnosis/snapshot/issues/1.
- Add loading to Gnosis Impact block https://github.com/gnosis/snapshot/issues/2.

Resolves: https://github.com/gnosis/snapshot/issues/1, https://github.com/gnosis/snapshot/issues/2
Require: https://github.com/snapshot-labs/snapshot.js/pull/49
