### PR TITLE
Calendar Year fix - always showing current year

### DIFF
--- a/src/components/Ui/Calendar.vue
+++ b/src/components/Ui/Calendar.vue
@@ -5,7 +5,7 @@
         class="col-3 iconfont iconback text-left h3 text-gray"
         @click="month--"
       />
-      <h4 class="mb-3 flex-auto text-center">{{ monthName }} {{ year }}</h4>
+      <h4 class="mb-3 flex-auto text-center">{{ monthName }} {{ fullYear }}</h4>
       <a
         class="col-3 iconfont icongo text-right h3 text-gray"
         @click="month++"
@@ -76,6 +76,9 @@ export default {
         }
       );
       return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+    },
+    fullYear() {
+      return new Date(this.year, this.month).getFullYear();
     },
     days() {
       return new Date(this.year, this.month + 1, 0).getDate();


### PR DESCRIPTION
Changes proposed in this pull request:
- Calendar showing the current year (2020) always
- Made it get Year based on the month selected

before: 
![image](https://user-images.githubusercontent.com/15967809/102745831-e4e5b180-4382-11eb-9ed1-e3f216493f0c.png)

after:
![image](https://user-images.githubusercontent.com/15967809/102745845-edd68300-4382-11eb-9061-a0caad9134b8.png)
