### PR TITLE
Fix broken link for custom domain documentation

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -97,7 +97,7 @@
                   <a
                     class="d-block py-1 mr-n2"
                     target="_blank"
-                    href="https://docs.snapshot.page/guides/custom-domain"
+                    href="https://docs.snapshot.page/guides/add-a-custom-domain"
                   >
                     <Icon name="info" size="24" class="text-gray p-1" />
                   </a>


### PR DESCRIPTION
There's a broken link present under the /settings page for a space.